### PR TITLE
adding android support

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/params/parsers/TabIconParser.java
+++ b/android/app/src/main/java/com/reactnativenavigation/params/parsers/TabIconParser.java
@@ -15,8 +15,10 @@ class TabIconParser extends Parser {
 
     public Drawable parse() {
         Drawable tabIcon = null;
-        if (hasKey(params, "icon")) {
-            tabIcon = ImageLoader.loadImage(params.getString("icon"));
+        if (hasKey(params, "androidDrawableClass")) {
+            tabIcon = ImageLoader.loadClass(params.getString("androidDrawableClass"));
+        } else if (hasKey(params, "icon")) {
+              tabIcon = ImageLoader.loadImage(params.getString("icon"));
         }
         return tabIcon;
     }

--- a/android/app/src/main/java/com/reactnativenavigation/params/parsers/TitleBarButtonParamsParser.java
+++ b/android/app/src/main/java/com/reactnativenavigation/params/parsers/TitleBarButtonParamsParser.java
@@ -22,8 +22,10 @@ public class TitleBarButtonParamsParser extends Parser {
     public TitleBarButtonParams parseSingleButton(Bundle bundle) {
         TitleBarButtonParams result = new TitleBarButtonParams();
         result.label = bundle.getString("title");
-        if (hasKey(bundle, "icon")) {
-            result.icon = ImageLoader.loadImage(bundle.getString("icon"));
+        if (hasKey(bundle, "androidDrawableClass")) {
+            result.icon = ImageLoader.loadClass(bundle.getString("androidDrawableClass"));
+        } else if (hasKey(bundle, "icon")) {
+              result.icon = ImageLoader.loadImage(bundle.getString("icon"));
         }
         result.color = getColor(bundle, "color", AppStyle.appStyle.titleBarButtonColor);
         result.disabledColor =

--- a/android/app/src/main/java/com/reactnativenavigation/react/ImageLoader.java
+++ b/android/app/src/main/java/com/reactnativenavigation/react/ImageLoader.java
@@ -1,10 +1,14 @@
 package com.reactnativenavigation.react;
 
+import android.content.Context;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
+import android.util.Log;
 
 import com.reactnativenavigation.NavigationApplication;
+
+import java.lang.reflect.Constructor;
 
 public class ImageLoader {
     private static final String FILE_SCHEME = "file";
@@ -19,6 +23,18 @@ public class ImageLoader {
             } else {
                 return loadResource(iconSource);
             }
+        }
+    }
+
+    public static Drawable loadClass(String className) {
+        Class clazz;
+        try {
+            clazz = Class.forName(className);
+            Constructor<?> constructor = clazz.getConstructor(Context.class);
+            return (Drawable) constructor.newInstance(NavigationApplication.instance);
+        } catch (Exception e) {
+            Log.e("ImageLoader", "error loading Drawable class '" + className + "'. " + e.getCause().getMessage(), e);
+            return null;
         }
     }
 

--- a/android/app/src/main/java/com/reactnativenavigation/react/ImageLoader.java
+++ b/android/app/src/main/java/com/reactnativenavigation/react/ImageLoader.java
@@ -26,6 +26,12 @@ public class ImageLoader {
         }
     }
 
+    /**
+     * Loads Drawable class, and returns new instance created with Context constructor.
+     *
+     * @param className Full qualified name of class.
+     * @return Newly created Drawable instance.
+     */
     public static Drawable loadClass(String className) {
         Class clazz;
         try {


### PR DESCRIPTION
WIP, no reviews yet pls

At the moment there is no way to use custom toolbar icon (only static images are allowed).

There are multiple issues, PRs that 'want' icon with badge in toolbar. Rather than providing solution with UI, this PR addresses the problem in more generic way, both android and ios can now pass the reference to native class, either ```Drawable``` or ```UIView```, which gets instantiated and then used as an icon in toolbar. This allows for scenarios like icon+badge or any other ones, when there is a need for custom icon.

See related PRs, issues:

- https://github.com/wix/react-native-navigation/pull/619

- https://github.com/wix/react-native-navigation/pull/593

- https://github.com/wix/react-native-navigation/pull/587

- https://github.com/wix/react-native-navigation/pull/459

- https://github.com/wix/react-native-navigation/issues/815

- https://github.com/wix/react-native-navigation/issues/755

- https://github.com/wix/react-native-navigation/issues/752

- https://github.com/wix/react-native-navigation/issues/706

- https://github.com/wix/react-native-navigation/issues/634

- https://github.com/wix/react-native-navigation/issues/606

- https://github.com/wix/react-native-navigation/issues/360

### USAGE:

There are 2 new attributes added to the buttons object (https://github.com/wix/react-native-navigation/wiki/Adding-buttons-to-the-navigator)


- ```androidDrawableClass``` - string value of fully qualified Drawable class. Has to contain constructor with ```Context``` param

- ```iosUIViewClass``` - string value of appName.className of a UIView class.

### EXAMPLE:

#### Android: 
```
package a.b.c;

public class CustomDrawable extends Drawable {

  // this constructor gets called by framework
  public CustomDrawable(Context ctx) {
   // your init code here
  }
  
  // your code here

}
```

```
androidDrawableClass: "a.b.c.CustomDrawable"
```

#### iOS:

```
class CustomUiVIew: UIView {
  
  // this constructor gets called by framework
  override initWithFrame(frame: CGRect) {
    // your init code here
  }
  
  // your code here
}
```

```
iosUIViewClass: "myApp.CustomUiVIew"
```
