### PR TITLE
Removed override keyword for JS create modules as per new RN standards. GX-7273

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/bridge/NavigationReactPackage.java
+++ b/android/app/src/main/java/com/reactnativenavigation/bridge/NavigationReactPackage.java
@@ -20,7 +20,7 @@ public class NavigationReactPackage implements ReactPackage {
         );
     }
 
-    @Override
+    // Depreciated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-navigation",
-  "version": "1.1.85",
+  "version": "1.1.86",
   "description": "React Native Navigation - truly native navigation for iOS and Android",
   "license": "MIT",
   "nativePackage": true,


### PR DESCRIPTION
Changed according to latest WIx RNN. https://github.com/wix/react-native-navigation/blob/master/android/app/src/main/java/com/reactnativenavigation/bridge/NavigationReactPackage.java#L23 

This is required as it is blocking for RN up-gradation