### PR TITLE
Adding support for custom android nav bar left icon

### DIFF
--- a/android/app/src/main/java/com/reactnativenavigation/params/parsers/TitleBarLeftButtonParamsParser.java
+++ b/android/app/src/main/java/com/reactnativenavigation/params/parsers/TitleBarLeftButtonParamsParser.java
@@ -12,6 +12,10 @@ public class TitleBarLeftButtonParamsParser extends TitleBarButtonParamsParser {
         if (params.isEmpty()) {
             return leftButtonParams;
         }
+        if (hasKey(params, "androidDrawableClass")) {
+            leftButtonParams.icon = ImageLoader.loadDrawableFromClassName(params.getString("androidDrawableClass"));
+            return leftButtonParams;
+        }
         leftButtonParams.iconState = getIconStateFromId(leftButtonParams.eventId);
         return leftButtonParams;
     }

--- a/docs/adding-buttons-to-the-navigator.md
+++ b/docs/adding-buttons-to-the-navigator.md
@@ -77,6 +77,8 @@ On Android, four button types are supported by default without the need to provi
 * accept
 * sideMenu
 
+Additionally, you can also render a custom icon by passing a fully qualified name of Android `Drawable` class as value to the key `androidDrawableClass`. 
+
 #### Custom Navigation Buttons
 
 On iOS, react-native-navigation uses `UIBarButtonItem` to display all items in the navigation bar. Instead of using images or text for normal `UIBarButtonItem`s, you can supply a custom component to be displayed within a custom view of a `UIBarButtonItem`, using the `component` property when specifying a navigation button.


### PR DESCRIPTION
[Feature - Android Only] Android will be able to support Drawable class for Navigation bar left button.

Example: 
```js
leftButtons: [{
    androidDrawableClass: "a.b.c.CustomDrawable"
  }]
```