### PR TITLE
[Fix] iOS Navbar text Custom Font support

### DIFF
--- a/ios/Helpers/RCCTitleViewHelper.m
+++ b/ios/Helpers/RCCTitleViewHelper.m
@@ -192,7 +192,8 @@ navigationController:(UINavigationController*)navigationController
     
     titleLabel.autoresizingMask = self.titleView.autoresizingMask;
     
-    UIFont *titleFont = [UIFont boldSystemFontOfSize:17.f];
+    NSString* fontFamily = style[@"navBarTextFontFamily"];
+    UIFont *titleFont = fontFamily ? [UIFont fontWithName:fontFamily size:17.f] : [UIFont boldSystemFontOfSize:17.f];
     
     id fontSize = style[@"navBarTitleFontSize"];
     if (fontSize) {

--- a/ios/Helpers/RCCTitleViewHelper.m
+++ b/ios/Helpers/RCCTitleViewHelper.m
@@ -191,10 +191,21 @@ navigationController:(UINavigationController*)navigationController
     titleLabel.backgroundColor = [UIColor clearColor];
     
     titleLabel.autoresizingMask = self.titleView.autoresizingMask;
-    
+  
+    CGFloat titleFontSizeFloat = 17.f;
+    id titleFontSize = style[@"navBarTextFontSize"];
+    if (titleFontSize) {
+        titleFontSizeFloat = [RCTConvert CGFloat:titleFontSize];
+    }
+
+    UIFont* titleFont = nil;
     NSString* fontFamily = style[@"navBarTextFontFamily"];
-    UIFont *titleFont = fontFamily ? [UIFont fontWithName:fontFamily size:17.f] : [UIFont boldSystemFontOfSize:17.f];
-    
+    if (fontFamily) {
+        titleFont = [UIFont fontWithName:fontFamily size:titleFontSizeFloat];
+    } else {
+        titleFont = [UIFont boldSystemFontOfSize:titleFontSizeFloat];
+    }
+  
     id fontSize = style[@"navBarTitleFontSize"];
     if (fontSize) {
         CGFloat fontSizeFloat = [RCTConvert CGFloat:fontSize];


### PR DESCRIPTION
Current RNN codebase does not adhere to the Docs for supporting `navBarTextFontFamily` attribute on iOS platform. 

Custom font support for Android was added in `https://github.com/wix/react-native-navigation/commit/86f397b782e23d91c8592270484cbb1106ad1f2d`

This PR aims to support `navBarTextFontFamily` and `navBarTitleFontSize` on iOS. If `navBarTextFontFamily` or `navBarTitleFontSize` are not passed, default font attributes are chosen.